### PR TITLE
Always insert newline after 'do'

### DIFF
--- a/data/examples/declaration/splice/bracket-declaration-out.hs
+++ b/data/examples/declaration/splice/bracket-declaration-out.hs
@@ -14,7 +14,8 @@ foo =
         deriving (Eq, Ord, Enum, Bounded, Show)
     |]
 
-$(do [d|baz = baz|])
+$(do
+      [d|baz = baz|])
 
 $(singletons [d|data T = T deriving (Eq, Ord, Enum, Bounded, Show)|])
 

--- a/data/examples/declaration/value/function/block-arguments-out.hs
+++ b/data/examples/declaration/value/function/block-arguments-out.hs
@@ -1,4 +1,5 @@
-f1 = foo do bar
+f1 = foo do
+    bar
 
 f2 = foo do
     bar
@@ -26,9 +27,13 @@ f7 = foo \x -> y
 f8 = foo \x ->
     y
 
-f9 = foo do { bar } baz
+f9 = foo do
+            { bar } baz
 
 f10 = foo
-    do a
-    do b
-    do c
+    do
+        a
+    do
+        b
+    do
+        c

--- a/data/examples/declaration/value/function/do/blocks-out.hs
+++ b/data/examples/declaration/value/function/do/blocks-out.hs
@@ -1,12 +1,16 @@
-foo = do bar
+foo = do
+    bar
 
-foo = do bar; baz
+foo = do
+    bar; baz
 
 foo = do
     bar
     baz
 
-foo = do do { foo; bar }; baz
+foo = do
+    do
+        { foo; bar }; baz
 
 readInClause = do
     do

--- a/data/examples/declaration/value/function/infix/do-out.hs
+++ b/data/examples/declaration/value/function/infix/do-out.hs
@@ -1,0 +1,16 @@
+main =
+    do
+        stuff
+        `finally` do
+            recover
+
+main = do
+    stuff `finally` recover
+
+main = do
+        { stuff } `finally` recover
+
+foo =
+    do
+        1
+        + 2

--- a/data/examples/declaration/value/function/let-single-line-out.hs
+++ b/data/examples/declaration/value/function/let-single-line-out.hs
@@ -4,7 +4,8 @@ foo x = let x = z where z = 2 in x
 foo x = let x = z where { z = 2 }; a = 3 in x
 foo x = let g :: Int -> Int; g = id in ()
 
-let a = b; c = do { foo; bar }; d = baz in b
+let a = b; c = do
+        { foo; bar }; d = baz in b
 let a = case True of { True -> foo; False -> bar }; b = foo a in b
 
 foo x = let ?g = id; ?f = g in x

--- a/data/examples/declaration/value/function/parens-out.hs
+++ b/data/examples/declaration/value/function/parens-out.hs
@@ -1,1 +1,2 @@
-f = p (do foo; bar) baz
+f = p (do
+            foo; bar) baz

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -671,7 +671,7 @@ p_hsExpr' s = \case
   HsDo NoExtField ctx es -> do
     let doBody header = do
           txt header
-          breakpoint
+          newline
           ub <- layoutToBraces <$> getLayout
           inci $
             sepSemi


### PR DESCRIPTION
Ugh, this is potentially a one-line fix, except that a handful of tests now fail with idempotence issues...

I guess we've gotta ask how much we care about holding ourselves to the same standards as the main `ormolu` branch in that respect. The upshot of not caring here would be that users may sometimes have to format twice if they write some really odd code using unusually compact `do`-notation.

Idempotence is obviously a valuable property, but if we start allowing some configuration, it's going to be increasingly difficult to guarantee in all cases anyway.

Fixes #1 (for good this time)