### PR TITLE
Stop operators from being indented past `do`.

### DIFF
--- a/data/examples/declaration/value/function/infix/do-out.hs
+++ b/data/examples/declaration/value/function/infix/do-out.hs
@@ -1,0 +1,13 @@
+main =
+    do stuff
+    `finally` do
+        recover
+
+main = do stuff `finally` recover
+
+main = do { stuff } `finally` recover
+
+foo =
+    do
+        1
+        + 2


### PR DESCRIPTION
The more I've thought about this, it seems that the behaviour causing the remaining test failure at #1 is really very specific to that sort of expression (a `do` block in the LHS of an infix operator). And frankly I'd be suspicious of code that looked like that anyway - before today I wouldn't have been confident at a glance of how that parses.

So I figure it's better to treat it as the unusual edge case it is. #5 seems overkill, since, as one fix led to another, the changes became more pervasive than we'd want, in terms of behaviour and LOC. This patch gets straight to the point, and is thus much smaller in both senses.