### PR TITLE
Add a config file

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,7 +10,6 @@ import Control.Exception (SomeException, displayException, try)
 import Control.Monad
 import Data.Either (lefts)
 import Data.List (intercalate, sort)
-import Data.Maybe (fromMaybe)
 import qualified Data.Text.IO as TIO
 import Data.Version (showVersion)
 import Development.GitRev
@@ -184,17 +183,7 @@ configParser =
                 help "End line of the region to format (inclusive)"
               ]
         )
-    <*> (fromMaybe defaultPrinterOpts <$> optional printerOptsParser)
-
-printerOptsParser :: Parser PrinterOpts
-printerOptsParser =
-  PrinterOpts
-    <$> (option auto . mconcat)
-      [ long "indent-step",
-        short 'i',
-        metavar "INT",
-        help "Number of spaces to use for indentation"
-      ]
+    <*> pure defaultPrinterOpts
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ import Control.Exception (SomeException, displayException, try)
 import Control.Monad
 import Data.Either (lefts)
 import Data.List (intercalate, sort)
+import Data.Maybe (fromMaybe)
 import qualified Data.Text.IO as TIO
 import Data.Version (showVersion)
 import Development.GitRev
@@ -183,6 +184,17 @@ configParser =
                 help "End line of the region to format (inclusive)"
               ]
         )
+    <*> (fromMaybe defaultPrinterOpts <$> optional printerOptsParser)
+
+printerOptsParser :: Parser PrinterOpts
+printerOptsParser =
+  PrinterOpts
+    <$> (option auto . mconcat)
+      [ long "indent-step",
+        short 'i',
+        metavar "INT",
+        help "Number of spaces to use for indentation"
+      ]
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -117,14 +117,18 @@ library
     default-language: Haskell2010
     build-depends:
         base >=4.12 && <5.0,
+        aeson >=1.5.2 && <1.6,
         bytestring >=0.2 && <0.11,
         containers >=0.5 && <0.7,
+        directory >= 1.3.5 && <1.4,
         dlist >=0.8 && <0.9,
         exceptions >=0.6 && <0.11,
+        filepath >=1.4.2.1 && <1.5,
         ghc-lib-parser >=8.10 && <8.11,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
-        text >=0.2 && <1.3
+        text >=0.2 && <1.3,
+        yaml >=0.11.2 && <0.12
 
     if flag(dev)
         ghc-options:

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,1 @@
+indentation: 4

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,1 +1,1 @@
-indentation: 4
+indentation: 2

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -9,6 +9,8 @@ module Ormolu
     RegionIndices (..),
     defaultConfig,
     DynOption (..),
+    PrinterOpts (..),
+    defaultPrinterOpts,
     OrmoluException (..),
     withPrettyOrmoluExceptions,
   )
@@ -62,7 +64,7 @@ ormolu cfgWithIndices path str = do
   -- about not-yet-supported functionality) will be thrown later when we try
   -- to parse the rendered code back, inside of GHC monad wrapper which will
   -- lead to error messages presenting the exceptions as GHC bugs.
-  let !txt = printModule result0
+  let !txt = printModule result0 $ cfgPrinterOpts cfgWithIndices
   when (not (cfgUnsafe cfg) || cfgCheckIdempotence cfg) $ do
     let pathRendered = path ++ "<rendered>"
     -- Parse the result of pretty-printing again and make sure that AST
@@ -80,7 +82,7 @@ ormolu cfgWithIndices path str = do
     -- Try re-formatting the formatted result to check if we get exactly
     -- the same output.
     when (cfgCheckIdempotence cfg) $
-      let txt2 = printModule result1
+      let txt2 = printModule result1 $ cfgPrinterOpts cfgWithIndices
        in case diffText txt txt2 pathRendered of
             Nothing -> return ()
             Just (loc, l, r) ->

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -52,11 +52,14 @@ ormolu ::
   String ->
   m Text
 ormolu cfgWithIndices path str = do
+  (cfgFileDebug, printerOpts) <-
+    liftIO $ loadConfigFile $ cfgPrinterOpts cfgWithIndices
   let totalLines = length (lines str)
       cfg = regionIndicesToDeltas totalLines <$> cfgWithIndices
   (warnings, result0) <-
     parseModule' cfg OrmoluParsingFailed path str
   when (cfgDebug cfg) $ do
+    traceM cfgFileDebug
     traceM "warnings:\n"
     traceM (concatMap showWarn warnings)
     traceM (prettyPrintParseResult result0)
@@ -64,7 +67,7 @@ ormolu cfgWithIndices path str = do
   -- about not-yet-supported functionality) will be thrown later when we try
   -- to parse the rendered code back, inside of GHC monad wrapper which will
   -- lead to error messages presenting the exceptions as GHC bugs.
-  let !txt = printModule result0 $ cfgPrinterOpts cfgWithIndices
+  let !txt = printModule result0 printerOpts
   when (not (cfgUnsafe cfg) || cfgCheckIdempotence cfg) $ do
     let pathRendered = path ++ "<rendered>"
     -- Parse the result of pretty-printing again and make sure that AST
@@ -82,7 +85,7 @@ ormolu cfgWithIndices path str = do
     -- Try re-formatting the formatted result to check if we get exactly
     -- the same output.
     when (cfgCheckIdempotence cfg) $
-      let txt2 = printModule result1 $ cfgPrinterOpts cfgWithIndices
+      let txt2 = printModule result1 printerOpts
        in case diffText txt txt2 pathRendered of
             Nothing -> return ()
             Just (loc, l, r) ->

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -7,6 +7,8 @@ module Ormolu.Config
     RegionIndices (..),
     RegionDeltas (..),
     defaultConfig,
+    PrinterOpts (..),
+    defaultPrinterOpts,
     regionIndicesToDeltas,
     DynOption (..),
     dynOptionToLocatedStr,
@@ -26,7 +28,8 @@ data Config region = Config
     -- | Checks if re-formatting the result is idempotent
     cfgCheckIdempotence :: !Bool,
     -- | Region selection
-    cfgRegion :: !region
+    cfgRegion :: !region,
+    cfgPrinterOpts :: PrinterOpts
   }
   deriving (Eq, Show, Functor)
 
@@ -61,8 +64,19 @@ defaultConfig =
         RegionIndices
           { regionStartLine = Nothing,
             regionEndLine = Nothing
-          }
+          },
+      cfgPrinterOpts = defaultPrinterOpts
     }
+
+-- | Options controlling formatting output
+data PrinterOpts = PrinterOpts
+  { -- | Number of spaces to use for indentation
+    poIndentStep :: Int
+  }
+  deriving (Eq, Show)
+
+defaultPrinterOpts :: PrinterOpts
+defaultPrinterOpts = PrinterOpts {poIndentStep = 4}
 
 -- | Convert 'RegionIndices' into 'RegionDeltas'.
 regionIndicesToDeltas ::

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -3,10 +3,12 @@
 -- | Pretty-printer for Haskell AST.
 module Ormolu.Printer
   ( printModule,
+    PrinterOpts (..),
   )
 where
 
 import Data.Text (Text)
+import Ormolu.Config
 import Ormolu.Parser.Result
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Module
@@ -17,9 +19,10 @@ import Ormolu.Processing.Postprocess (postprocess)
 printModule ::
   -- | Result of parsing
   ParseResult ->
+  PrinterOpts ->
   -- | Resulting rendition
   Text
-printModule ParseResult {..} =
+printModule ParseResult {..} printerOpts =
   prLiteralPrefix <> region <> prLiteralSuffix
   where
     region =
@@ -35,4 +38,5 @@ printModule ParseResult {..} =
           (mkSpanStream prParsedSource)
           prCommentStream
           prAnns
+          printerOpts
           prUseRecordDot


### PR DESCRIPTION
Closes #2.

Fourmolu looks through parent directories, then [the XDG config directory](https://hackage.haskell.org/package/directory-1.3.6.1/docs/System-Directory.html#v:XdgConfig), for a `fourmolu.yaml`, which is used to override config fields. Right now, the only field is `indentation`.

So a config file just looks like:
```yaml
indentation: 4
```