### PR TITLE
Add support for config files

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -183,6 +183,7 @@ configParser =
                 help "End line of the region to format (inclusive)"
               ]
         )
+    <*> pure defaultPrinterOpts
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -25,7 +25,10 @@ import System.IO (hPutStrLn, stderr)
 main :: IO ()
 main = withPrettyOrmoluExceptions $ do
   Opts {..} <- execParser optsParserInfo
-  let formatOne' = formatOne optMode optConfig
+  let formatOne' path = do
+        printerOpts <-
+          loadConfigFile (cfgDebug optConfig) path $ cfgPrinterOpts optConfig
+        formatOne optMode optConfig {cfgPrinterOpts = printerOpts} path
   case optInputFiles of
     [] -> formatOne' Nothing
     ["-"] -> formatOne' Nothing

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -116,15 +116,19 @@ library
 
     default-language: Haskell2010
     build-depends:
+        aeson >=1.5.2 && <1.6,
         base >=4.12 && <5.0,
         bytestring >=0.2 && <0.11,
         containers >=0.5 && <0.7,
+        directory >= 1.3.5 && <1.4,
         dlist >=0.8 && <0.9,
         exceptions >=0.6 && <0.11,
+        filepath >=1.4.2.1 && <1.5,
         ghc-lib-parser >=8.10 && <8.11,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
-        text >=0.2 && <1.3
+        text >=0.2 && <1.3,
+        yaml >=0.11.2 && <0.12
 
     if flag(dev)
         ghc-options:

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,1 @@
+indentation: 2

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -11,6 +11,7 @@ module Ormolu
     DynOption (..),
     PrinterOpts (..),
     defaultPrinterOpts,
+    loadConfigFile,
     OrmoluException (..),
     withPrettyOrmoluExceptions,
   )
@@ -52,14 +53,11 @@ ormolu ::
   String ->
   m Text
 ormolu cfgWithIndices path str = do
-  (cfgFileDebug, printerOpts) <-
-    liftIO $ loadConfigFile $ cfgPrinterOpts cfgWithIndices
   let totalLines = length (lines str)
       cfg = regionIndicesToDeltas totalLines <$> cfgWithIndices
   (warnings, result0) <-
     parseModule' cfg OrmoluParsingFailed path str
   when (cfgDebug cfg) $ do
-    traceM cfgFileDebug
     traceM "warnings:\n"
     traceM (concatMap showWarn warnings)
     traceM (prettyPrintParseResult result0)
@@ -67,7 +65,7 @@ ormolu cfgWithIndices path str = do
   -- about not-yet-supported functionality) will be thrown later when we try
   -- to parse the rendered code back, inside of GHC monad wrapper which will
   -- lead to error messages presenting the exceptions as GHC bugs.
-  let !txt = printModule result0 printerOpts
+  let !txt = printModule result0 $ cfgPrinterOpts cfgWithIndices
   when (not (cfgUnsafe cfg) || cfgCheckIdempotence cfg) $ do
     let pathRendered = path ++ "<rendered>"
     -- Parse the result of pretty-printing again and make sure that AST
@@ -85,7 +83,7 @@ ormolu cfgWithIndices path str = do
     -- Try re-formatting the formatted result to check if we get exactly
     -- the same output.
     when (cfgCheckIdempotence cfg) $
-      let txt2 = printModule result1 printerOpts
+      let txt2 = printModule result1 $ cfgPrinterOpts cfgWithIndices
        in case diffText txt txt2 pathRendered of
             Nothing -> return ()
             Just (loc, l, r) ->

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -9,6 +9,8 @@ module Ormolu
     RegionIndices (..),
     defaultConfig,
     DynOption (..),
+    PrinterOpts (..),
+    defaultPrinterOpts,
     OrmoluException (..),
     withPrettyOrmoluExceptions,
   )
@@ -50,11 +52,14 @@ ormolu ::
   String ->
   m Text
 ormolu cfgWithIndices path str = do
+  (cfgFileDebug, printerOpts) <-
+    liftIO $ loadConfigFile $ cfgPrinterOpts cfgWithIndices
   let totalLines = length (lines str)
       cfg = regionIndicesToDeltas totalLines <$> cfgWithIndices
   (warnings, result0) <-
     parseModule' cfg OrmoluParsingFailed path str
   when (cfgDebug cfg) $ do
+    traceM cfgFileDebug
     traceM "warnings:\n"
     traceM (concatMap showWarn warnings)
     traceM (prettyPrintParseResult result0)
@@ -62,7 +67,7 @@ ormolu cfgWithIndices path str = do
   -- about not-yet-supported functionality) will be thrown later when we try
   -- to parse the rendered code back, inside of GHC monad wrapper which will
   -- lead to error messages presenting the exceptions as GHC bugs.
-  let !txt = printModule result0
+  let !txt = printModule result0 printerOpts
   when (not (cfgUnsafe cfg) || cfgCheckIdempotence cfg) $ do
     let pathRendered = path ++ "<rendered>"
     -- Parse the result of pretty-printing again and make sure that AST
@@ -80,7 +85,7 @@ ormolu cfgWithIndices path str = do
     -- Try re-formatting the formatted result to check if we get exactly
     -- the same output.
     when (cfgCheckIdempotence cfg) $
-      let txt2 = printModule result1
+      let txt2 = printModule result1 printerOpts
        in case diffText txt txt2 pathRendered of
             Nothing -> return ()
             Just (loc, l, r) ->

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Configuration options used by the tool.
@@ -7,13 +9,37 @@ module Ormolu.Config
     RegionIndices (..),
     RegionDeltas (..),
     defaultConfig,
+    PrinterOpts (..),
+    defaultPrinterOpts,
+    loadConfigFile,
     regionIndicesToDeltas,
     DynOption (..),
     dynOptionToLocatedStr,
   )
 where
 
+import Data.Aeson
+  ( FromJSON (..),
+    camelTo2,
+    defaultOptions,
+    fieldLabelModifier,
+    rejectUnknownFields,
+    genericParseJSON,
+  )
+import Data.Bifunctor (bimap)
+import Data.Functor ((<&>))
+import Data.List (stripPrefix)
+import Data.Maybe (fromMaybe)
+import Data.Yaml (ParseException, decodeFileEither, prettyPrintParseException)
+import GHC.Generics (Generic)
 import qualified SrcLoc as GHC
+import System.Directory
+  ( XdgDirectory (XdgConfig),
+    findFile,
+    getCurrentDirectory,
+    getXdgDirectory,
+  )
+import System.FilePath ((</>), splitPath)
 
 -- | Ormolu configuration.
 data Config region = Config
@@ -26,7 +52,8 @@ data Config region = Config
     -- | Checks if re-formatting the result is idempotent
     cfgCheckIdempotence :: !Bool,
     -- | Region selection
-    cfgRegion :: !region
+    cfgRegion :: !region,
+    cfgPrinterOpts :: PrinterOpts
   }
   deriving (Eq, Show, Functor)
 
@@ -61,8 +88,19 @@ defaultConfig =
         RegionIndices
           { regionStartLine = Nothing,
             regionEndLine = Nothing
-          }
+          },
+      cfgPrinterOpts = defaultPrinterOpts
     }
+
+-- | Options controlling formatting output
+data PrinterOpts = PrinterOpts
+  { -- | Number of spaces to use for indentation
+    poIndentStep :: Int
+  }
+  deriving (Eq, Show)
+
+defaultPrinterOpts :: PrinterOpts
+defaultPrinterOpts = PrinterOpts {poIndentStep = 4}
 
 -- | Convert 'RegionIndices' into 'RegionDeltas'.
 regionIndicesToDeltas ::
@@ -87,3 +125,64 @@ newtype DynOption = DynOption
 -- | Convert 'DynOption' to @'GHC.Located' 'String'@.
 dynOptionToLocatedStr :: DynOption -> GHC.Located String
 dynOptionToLocatedStr (DynOption o) = GHC.L GHC.noSrcSpan o
+
+-- | A version of 'PrinterOpts' where any field can be empty.
+-- This corresponds to the information in a config file.
+data PrinterOptsPartial = PrinterOptsPartial
+  { popIndentation :: Maybe Int
+  }
+  deriving (Eq, Show, Generic)
+
+instance FromJSON PrinterOptsPartial where
+  parseJSON =
+    genericParseJSON
+      defaultOptions
+        { rejectUnknownFields = True,
+          fieldLabelModifier = camelTo2 '_' . fromMaybe "" . stripPrefix "pop"
+        }
+
+-- | Replace fields with those from a config file, if found.
+-- First element of tuple contains debugging output.
+loadConfigFile :: PrinterOpts -> IO (String, PrinterOpts)
+loadConfigFile PrinterOpts {..} =
+  bimap prettyFileResult replaceWithFileOpts <$> getOptsFromFile
+  where
+    replaceWithFileOpts PrinterOptsPartial {..} =
+      PrinterOpts
+        { poIndentStep = fromMaybe poIndentStep popIndentation
+        }
+
+-- | Looks recursively in parent folders, then in 'XdgConfig',
+-- for a file matching 'configFileName'.
+getOptsFromFile :: IO (FileResult, PrinterOptsPartial)
+getOptsFromFile = do
+  cur <- getCurrentDirectory
+  xdg <- getXdgDirectory XdgConfig ""
+  let dirs = reverse $ xdg : scanl1 (</>) (splitPath cur)
+  findFile dirs configFileName >>= \case
+    Nothing -> return (NoFileFound cur xdg, def)
+    Just file -> decodeFileEither file <&> \case
+      Left e -> (FileFound file (Just e), def)
+      Right x -> (FileFound file Nothing, x)
+  where
+    def = PrinterOptsPartial Nothing
+
+-- | Useful information for debugging config file searching and parsing.
+data FileResult
+  = NoFileFound
+      FilePath -- current directory
+      FilePath -- XDG config directory
+  | FileFound FilePath (Maybe ParseException)
+
+prettyFileResult :: FileResult -> String
+prettyFileResult = \case
+  NoFileFound cur xdg ->
+    "No \"" ++ configFileName ++ "\" found in " ++ xdg
+      ++ " or parents of "
+      ++ cur
+  FileFound f m ->
+    "Found \"" ++ f ++ "\""
+      ++ maybe "" ((":\n" ++) . prettyPrintParseException) m
+
+configFileName :: FilePath
+configFileName = "fourmolu.yaml"

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -3,10 +3,12 @@
 -- | Pretty-printer for Haskell AST.
 module Ormolu.Printer
   ( printModule,
+    PrinterOpts (..),
   )
 where
 
 import Data.Text (Text)
+import Ormolu.Config
 import Ormolu.Parser.Result
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Module
@@ -17,9 +19,10 @@ import Ormolu.Processing.Postprocess (postprocess)
 printModule ::
   -- | Result of parsing
   ParseResult ->
+  PrinterOpts ->
   -- | Resulting rendition
   Text
-printModule ParseResult {..} =
+printModule ParseResult {..} printerOpts =
   prLiteralPrefix <> region <> prLiteralSuffix
   where
     region =
@@ -35,4 +38,5 @@ printModule ParseResult {..} =
           (mkSpanStream prParsedSource)
           prCommentStream
           prAnns
+          printerOpts
           prUseRecordDot


### PR DESCRIPTION
Closes #2.

Fourmolu looks through parent directories, then [the XDG config directory](https://hackage.haskell.org/package/directory-1.3.6.1/docs/System-Directory.html#v:XdgConfig), for a `fourmolu.yaml`, which is used to override config fields. Right now, the only field is `indentation`.

So a config file just looks like:
```yaml
indentation: 4
```