### PR TITLE
Fix `stack.yaml` (`aeson-1.5.2.0` dependency).

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2020-05-16
+resolver: lts-16.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,6 +40,9 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 # extra-deps: []
+
+extra-deps:
+  - aeson-1.5.2.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
As reported in #12, because of the `aeson-1.5.2.0` dependency, the project didn't build with using neither the `stack.yaml` file in the repo, nor the one described in the `README`. I am able to build it using the `stack.yaml` as in this PR. 

However, this boosts the required GHC version to 8.8.3. Probably `lts-15.3` (GHC 8.8.2) would also work. I'm not sure what the best practice is.

I didn't manage to build it using `stack` and GHC 8.6.5.