### PR TITLE
Add --indentation CLI option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the following goals in mind:
   leaves some control to the user while still guaranteeing that the
   formatted code is stylistically consistent.
 * Writing code in such a way so it's easy to modify and maintain.
-* Implementing one “true” formatting style ~~which admits no configuration~~ requires you to fork the project to configure it (TODO: add a config file).
+* Implementing one “true” formatting style ~~which admits no configuration~~ requires you to fork the project to configure it.
 * That formatting style aims to result in minimal diffs while still
   remaining very close to “conventional” Haskell formatting people use.
 * Choose a style compatible with modern dialects of Haskell. As new Haskell
@@ -96,6 +96,9 @@ Use `find` to format a tree recursively:
 ```console
 $ ormolu --mode inplace $(find . -name '*.hs')
 ```
+
+Add `--indentation 4` (or edit the `fourmolu.yaml` config file) to
+change the indentation width to 4 spaces.
 
 ## Magic comments
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -33,8 +33,8 @@ main = withPrettyOrmoluExceptions $ do
           optConfig
             { cfgPrinterOpts =
                 mergePrinterOpts
-                  [optPrinterOpts, filePrinterOpts]
-                  defaultPrinterOpts
+                  (optPrinterOpts <> filePrinterOpts)
+                  (cfgPrinterOpts optConfig)
             }
           path
   case optInputFiles of
@@ -197,7 +197,7 @@ configParser =
                 help "End line of the region to format (inclusive)"
               ]
         )
-    <*> pure defaultPrinterOpts -- just a placeholder that is overwritten later
+    <*> pure defaultPrinterOpts
 
 printerOptsParser :: Parser PrinterOptsPartial
 printerOptsParser =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -205,7 +205,7 @@ printerOptsParser =
     <$> (optional . option auto . mconcat)
       [ long "indentation",
         metavar "WIDTH",
-        help "Number of spaces per indentation step"
+        help "Number of spaces per indentation step (default 4)"
       ]
 
 ----------------------------------------------------------------------------

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,7 +32,7 @@ main = withPrettyOrmoluExceptions $ do
           optMode
           optConfig
             { cfgPrinterOpts =
-                mergePrinterOpts
+                fillMissingPrinterOpts
                   (optPrinterOpts <> filePrinterOpts)
                   (cfgPrinterOpts optConfig)
             }

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -10,8 +10,11 @@ module Ormolu
     defaultConfig,
     DynOption (..),
     PrinterOpts (..),
+    PrinterOptsPartial,
+    PrinterOptsTotal,
     defaultPrinterOpts,
     loadConfigFile,
+    mergePrinterOpts,
     OrmoluException (..),
     withPrettyOrmoluExceptions,
   )

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -14,7 +14,7 @@ module Ormolu
     PrinterOptsTotal,
     defaultPrinterOpts,
     loadConfigFile,
-    mergePrinterOpts,
+    fillMissingPrinterOpts,
     OrmoluException (..),
     withPrettyOrmoluExceptions,
   )

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -16,7 +16,7 @@ module Ormolu.Config
     PrinterOptsTotal,
     defaultPrinterOpts,
     loadConfigFile,
-    mergePrinterOpts,
+    fillMissingPrinterOpts,
     regionIndicesToDeltas,
     DynOption (..),
     dynOptionToLocatedStr,
@@ -115,7 +115,7 @@ deriving instance Eq PrinterOptsPartial
 deriving instance Show PrinterOptsPartial
 
 instance Semigroup PrinterOptsPartial where
-  (<>) = mergePrinterOpts
+  (<>) = fillMissingPrinterOpts
 
 instance Monoid PrinterOptsPartial where
   mempty = PrinterOpts {poIndentation = Nothing}
@@ -132,17 +132,18 @@ defaultPrinterOpts = PrinterOpts {poIndentation = Identity 4}
 
 -- | Fill the field values that are 'Nothing' in the first argument
 -- with the values of the corresponding fields of the second argument.
-mergePrinterOpts ::
+fillMissingPrinterOpts ::
   (Applicative f) =>
   PrinterOptsPartial ->
   PrinterOpts f ->
   PrinterOpts f
-mergePrinterOpts p1 p2 =
-  PrinterOpts {poIndentation = m poIndentation poIndentation}
+fillMissingPrinterOpts p1 p2 =
+  PrinterOpts {poIndentation = fillField poIndentation poIndentation}
   where
-    m f1 f2 = case f1 p1 of
-      Nothing -> f2 p2
-      Just x -> pure x
+    fillField f1 f2 =
+      case f1 p1 of
+        Nothing -> f2 p2
+        Just x -> pure x
 
 -- | Convert 'RegionIndices' into 'RegionDeltas'.
 regionIndicesToDeltas ::

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -19,7 +19,7 @@ import Ormolu.Processing.Postprocess (postprocess)
 printModule ::
   -- | Result of parsing
   ParseResult ->
-  PrinterOpts ->
+  PrinterOptsTotal ->
   -- | Resulting rendition
   Text
 printModule ParseResult {..} printerOpts =

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -57,6 +57,7 @@ import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.Bool (bool)
 import Data.Coerce
+import Data.Functor.Identity (runIdentity)
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -94,7 +95,7 @@ data RC = RC
     rcCanUseBraces :: Bool,
     -- | Whether the source could have used the record dot preprocessor
     rcUseRecDot :: Bool,
-    rcPrinterOpts :: PrinterOpts
+    rcPrinterOpts :: PrinterOptsTotal
   }
 
 -- | State context of 'R'.
@@ -160,7 +161,7 @@ runR ::
   CommentStream ->
   -- | Annotations
   Anns ->
-  PrinterOpts ->
+  PrinterOptsTotal ->
   -- | Use Record Dot Syntax
   Bool ->
   -- | Resulting rendition
@@ -378,7 +379,7 @@ useRecordDot = R (asks rcUseRecDot)
 -- effect, but with multi-line layout correct indentation levels matter.
 inci :: R () -> R ()
 inci (R m) = do
-  indentStep <- R (asks (poIndentStep . rcPrinterOpts))
+  indentStep <- R (asks (runIdentity . poIndentation . rcPrinterOpts))
   let modRC rc =
         rc
           { rcIndent = rcIndent rc + indentStep

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -5,6 +5,7 @@ module Ormolu.PrinterSpec (spec) where
 import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
+import Data.Functor.Identity (Identity (..))
 import Data.List (isSuffixOf)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -24,7 +25,7 @@ spec = do
 checkExample :: Path Rel File -> Spec
 checkExample srcPath' = it (fromRelFile srcPath' ++ " works") . withNiceExceptions $ do
   let srcPath = examplesDir </> srcPath'
-      cfg = defaultConfig {cfgPrinterOpts = PrinterOpts {poIndentStep = 2}}
+      cfg = defaultConfig {cfgPrinterOpts = PrinterOpts {poIndentation = Identity 2}}
   expectedOutputPath <- deriveOutput srcPath
   -- 1. Given input snippet of source code parse it and pretty print it.
   -- 2. Parse the result of pretty-printing again and make sure that AST


### PR DESCRIPTION
This took me longer than I planned, but finally here's a working version that solves #12. In the end I decided to follow the approach proposed by @georgefst, but perhaps I've stopped a few steps earlier than it was intended.

I've had a number of decisions to make, and I'll try to explain myself.

* There's no short version of the `--indentation` option: I wanted to avoid conflicts with `ormolu` if they add an `-i` option in the future.
* I'm not sure if deriving `Eq` and `Show` for `PrinterOptsPartial` and `PrinterOptsTotal` is done the "right" way. I wanted to stay conservative. The  `StandaloneDeriving` extension seemed safer to me than `UndecidableInstances`, which could perhaps allow me to save a few lines (but I'm not even sure about that, I have not tried).
* I've not defined a HKD type family, as described in some tutorials like https://reasonablypolymorphic.com/blog/higher-kinded-data/, which would allow me to get rid of the `Identity` wrapping. I don't find the `Identity` such a great nuisance at the moment. I don't understand how the type families work, so I didn't want to introduce "magic" (and an additional language extension) just to clean it up.
* I have not defined a `Semigroup` instance for `PrinterOptsPartial`. I don't really need it at the moment, and I didn't know how to do it in a slick way. If I wrote an instance by hand, then every time a new field was added to `PrinterOpts` one would have to change both the `Semigroup` instance and another function, used to merge `PrinterOptsPartial` with `PrinterOptsTotal`. I don't know how to do it in a generic way without much effort or additional dependencies.
* On the other hand I'm not really satisfied with the `mergePrinterOpts` function:
```haskell
mergePrinterOpts :: [PrinterOptsPartial] -> PrinterOptsTotal -> PrinterOptsTotal
mergePrinterOpts opts totalOpts = PrinterOpts{ poIndentation = m poIndentation poIndentation }
  where
    m :: (PrinterOptsTotal -> Identity a) -> (PrinterOptsPartial -> Maybe a) -> Identity a
    m ft fp = Identity $ fromMaybe (runIdentity . ft $ totalOpts) (asum $ map fp opts)
```
  I'd like to have something like `m :: (PrinterOpts f -> f a) -> Identity a`, so that I could write `poIndentation = m poIndentation`, but again I don't see how this could be achieved without much effort.