### PR TITLE
Fix formatting script

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -4,6 +4,7 @@ set -e
 
 cabal format
 
-cabal run fourmolu -- -i $(find app -type f -name "*.hs")
-cabal run fourmolu -- -i $(find src -type f \( -name "*.hs" -o -name "*.hs-boot" \))
-cabal run fourmolu -- -i $(find tests -type f -name "*.hs")
+fourmolu -i \
+    $(find app -type f -name "*.hs") \
+    $(find src -type f \( -name "*.hs" -o -name "*.hs-boot" \)) \
+    $(find tests -type f -name "*.hs") \

--- a/format.sh
+++ b/format.sh
@@ -2,10 +2,8 @@
 
 set -e
 
-export LANG="C.UTF-8"
-
 cabal format
 
-fourmolu -i $(find app -type f -name "*.hs")
-fourmolu -i $(find src -type f \( -name "*.hs" -o -name "*.hs-boot" \))
-fourmolu -i $(find tests -type f -name "*.hs")
+cabal run fourmolu -- -i $(find app -type f -name "*.hs")
+cabal run fourmolu -- -i $(find src -type f \( -name "*.hs" -o -name "*.hs-boot" \))
+cabal run fourmolu -- -i $(find tests -type f -name "*.hs")

--- a/format.sh
+++ b/format.sh
@@ -4,7 +4,7 @@ set -e
 
 cabal format
 
-fourmolu -i \
+cabal run fourmolu -- -i \
     $(find app -type f -name "*.hs") \
     $(find src -type f \( -name "*.hs" -o -name "*.hs-boot" \)) \
     $(find tests -type f -name "*.hs") \


### PR DESCRIPTION
I got burnt by the fact that it was using the globally installed `fourmolu`, rather than the current source...

This fix still isn't really ideal, as there can be a lot of recompilation before reaching a fixed point. What might be nicest is to wait until `cabal run` allows using the bytecode interpreter.