### PR TITLE
Use multiline comment style for multiline haddocks

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -244,6 +244,11 @@ printerOptsParser =
         metavar "BOOL",
         help "Give the programmer more choice on where to insert blank lines (default 'true')"
       ]
+    <*> (optional . option parseHaddockStyle . mconcat)
+      [ long "haddock-style",
+        metavar "STYLE",
+        help "How to print Haddock comments (default 'multi-line')"
+      ]
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -262,6 +267,13 @@ parseCommaStyle = eitherReader $ \case
   "leading" -> Right Leading
   "trailing" -> Right Trailing
   s -> Left $ "unknown comma style: " ++ s
+
+-- | Parse 'HaddockStyle'.
+parseHaddockStyle :: ReadM HaddockPrintStyle
+parseHaddockStyle = eitherReader $ \case
+  "single-line" -> Right HaddockSingleLine
+  "multi-line" -> Right HaddockMultiLine
+  s -> Left $ "unknown haddock style: " ++ s
 
 -- | Parse a 'Bool'. Unlike 'auto', this is not case sensitive.
 parseBool :: ReadM Bool

--- a/data/examples/module-header/leading-empty-line-four-out.hs
+++ b/data/examples/module-header/leading-empty-line-four-out.hs
@@ -1,11 +1,12 @@
--- |
--- Module      :  Text.Megaparsec
--- Copyright   :  © 2015–2019 Megaparsec contributors
---                © 2007 Paolo Martini
---                © 1999–2001 Daan Leijen
--- License     :  FreeBSD
---
--- Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
--- Stability   :  experimental
--- Portability :  portable
+{- |
+ Module      :  Text.Megaparsec
+ Copyright   :  © 2015–2019 Megaparsec contributors
+                © 2007 Paolo Martini
+                © 1999–2001 Daan Leijen
+ License     :  FreeBSD
+
+ Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
+ Stability   :  experimental
+ Portability :  portable
+-}
 module Main where

--- a/data/examples/module-header/named-section-four-out.hs
+++ b/data/examples/module-header/named-section-four-out.hs
@@ -7,6 +7,7 @@ module Magic (
     bar,
 ) where
 
--- $explanation
---
--- Here it goes.
+{- $explanation
+
+ Here it goes.
+-}

--- a/data/examples/other/comment-style-transform-four-out.hs
+++ b/data/examples/other/comment-style-transform-four-out.hs
@@ -1,17 +1,19 @@
--- |
--- Module:      Data.Aeson.TH
--- Copyright:   (c) 2011-2016 Bryan O'Sullivan
---              (c) 2011 MailRank, Inc.
--- License:     BSD3
--- Stability:   experimental
--- Portability: portable
+{- |
+Module:      Data.Aeson.TH
+Copyright:   (c) 2011-2016 Bryan O'Sullivan
+             (c) 2011 MailRank, Inc.
+License:     BSD3
+Stability:   experimental
+Portability: portable
+-}
 module Main where
 
--- |
---
--- Here is a snippet:
---
--- @
--- x = y + 2
--- @
+{- |
+
+Here is a snippet:
+
+@
+x = y + 2
+@
+-}
 x = y + 2

--- a/data/examples/other/comment-style-transform-out.hs
+++ b/data/examples/other/comment-style-transform-out.hs
@@ -1,17 +1,17 @@
 -- |
--- Module:      Data.Aeson.TH
--- Copyright:   (c) 2011-2016 Bryan O'Sullivan
---              (c) 2011 MailRank, Inc.
--- License:     BSD3
--- Stability:   experimental
--- Portability: portable
+--Module:      Data.Aeson.TH
+--Copyright:   (c) 2011-2016 Bryan O'Sullivan
+--             (c) 2011 MailRank, Inc.
+--License:     BSD3
+--Stability:   experimental
+--Portability: portable
 module Main where
 
 -- |
 --
--- Here is a snippet:
+--Here is a snippet:
 --
--- @
--- x = y + 2
--- @
+--@
+--x = y + 2
+--@
 x = y + 2

--- a/data/examples/other/following-comment-last-3-four-out.hs
+++ b/data/examples/other/following-comment-last-3-four-out.hs
@@ -2,5 +2,6 @@ module Main where
 
 -- | Another datatype...
 data D'
--- ^ ...with two docstrings.
--- even on second line
+{- ^ ...with two docstrings.
+ even on second line
+-}

--- a/data/examples/other/haddock-sections-four-out.hs
+++ b/data/examples/other/haddock-sections-four-out.hs
@@ -1,7 +1,9 @@
--- $weird #anchor#
---
--- Section 1
+{- $weird #anchor#
 
--- $normal
---
--- Section 2
+ Section 1
+-}
+
+{- $normal
+
+ Section 2
+-}

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -4,3 +4,4 @@ record-brace-space: true
 indent-wheres: true
 diff-friendly-import-export: false
 preserve-spacing: false
+haddock-style: single-line

--- a/src/Ormolu/Parser/CommentStream.hs
+++ b/src/Ormolu/Parser/CommentStream.hs
@@ -86,7 +86,7 @@ showCommentStream (CommentStream xs) =
 
 -- | A wrapper for a single comment. The 'Bool' indicates whether there were
 -- atoms before beginning of the comment in the original input. The
--- 'NonEmpty' list inside contains lines of multiline comment @{- … -}@ or
+-- 'NonEmpty' list inside contains lines of multiline comment @{\- … -\}@ or
 -- just single item\/line otherwise.
 data Comment = Comment Bool (NonEmpty String)
   deriving (Eq, Show, Data)

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -233,7 +233,7 @@ parens = brackets_ False "(" ")"
 parensHash :: BracketStyle -> R () -> R ()
 parensHash = brackets_ True "(#" "#)"
 
--- | Braces as used for pragmas: @{-#@ and @#-}@.
+-- | Braces as used for pragmas: @{\-#@ and @#-\}@.
 pragmaBraces :: R () -> R ()
 pragmaBraces m = sitcc $ do
   txt "{-#"

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -11,6 +11,7 @@ module Ormolu.Printer.Meat.ImportExport
 where
 
 import Control.Monad
+import qualified Data.Text as T
 import GHC
 import Ormolu.Config (poDiffFriendlyImportExport)
 import Ormolu.Printer.Combinators
@@ -115,7 +116,7 @@ p_lie encLayout relativePos = \case
     p_hsDocString (Asterisk n) False (noLoc str)
   IEDoc NoExtField str ->
     p_hsDocString Pipe False (noLoc str)
-  IEDocNamed NoExtField str -> p_hsDocName str
+  IEDocNamed NoExtField str -> txt $ "-- $" <> T.pack str
   XIE x -> noExtCon x
   where
     p_comma =

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -73,7 +73,6 @@ splitDocString docStr =
   where
     r =
       fmap escapeLeadingDollar
-        . dropPaddingSpace
         . dropWhileEnd T.null
         . fmap (T.stripEnd . T.pack)
         . lines
@@ -85,20 +84,6 @@ splitDocString docStr =
       case T.uncons txt of
         Just ('$', _) -> T.cons '\\' txt
         _ -> txt
-    dropPaddingSpace xs =
-      case dropWhile T.null xs of
-        [] -> []
-        (x : _) ->
-          let leadingSpace txt = case T.uncons txt of
-                Just (' ', _) -> True
-                _ -> False
-              dropSpace txt =
-                if leadingSpace txt
-                  then T.drop 1 txt
-                  else txt
-           in if leadingSpace x
-                then dropSpace <$> xs
-                else xs
 
 -- | Get 'LHsType' out of 'LHsTypeArg'.
 typeArgToType :: LHsTypeArg p -> LHsType p

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -72,7 +72,7 @@ splitDocString docStr =
     _ -> r
   where
     r =
-      fmap escapeLeadingDollar
+      fmap (escapeLeadingDollar . escapeCommentBraces)
         . dropWhileEnd T.null
         . fmap (T.stripEnd . T.pack)
         . lines
@@ -84,6 +84,7 @@ splitDocString docStr =
       case T.uncons txt of
         Just ('$', _) -> T.cons '\\' txt
         _ -> txt
+    escapeCommentBraces = T.replace "{-" "{\\-" . T.replace "-}" "-\\}"
 
 -- | Get 'LHsType' out of 'LHsTypeArg'.
 typeArgToType :: LHsTypeArg p -> LHsType p

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -26,7 +26,8 @@ spec = do
             poIndentWheres = pure True,
             poRecordBraceSpace = pure True,
             poDiffFriendlyImportExport = pure False,
-            poPreserveSpacing = pure False
+            poPreserveSpacing = pure False,
+            poHaddockStyle = pure HaddockSingleLine
           }
   sequence_ $ uncurry checkExample <$> [(ormoluOpts, ""), (defaultPrinterOpts, "-four")] <*> es
 


### PR DESCRIPTION
My initial intention here was just to preserve haddock comments completely. But that seems to be difficult, since the GHC API doesn't actually tell us, for example, whether a comment used single-line (`--`) or multi-line (`{- -}`) style. We *could* use the `SrcSpan`s to grab the appropriate text from the input verbatim, but that's a bit nasty.

So, I've gone with @michaelpj's suggestion from [the Ormolu thread about this](https://github.com/tweag/ormolu/issues/641), which is to always print in multi-line style for multi-line haddocks, even if they originally just used multiple `--`s. One slight gotcha is that:

```hs
-- | Multi
-- line
-- comment
```

becomes:
```hs
{- | Multi
 line
 comment
-}
```

, when it might seem more natural for the leading spaces to be removed. And, depending on the user's editor, this might be non-trivial to "fix". But I can't see a good general solution to that, that wouldn't strip leading whitespace from multi-line-style comments, where it is likely to be intentional.


If we care about keeping the guarantee that Fourmolu is completely compatible with Ormolu (e.g. so we can continue to dogfood without introducing large diffs vs. upstream), then we ought to make this configurable like everything else. Although I do find the existing behaviour difficult to justify.