### PR TITLE
Replace hardcoded defaults. Remove parser boilerplate. (#27)

### DIFF
--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -180,7 +180,7 @@ fillMissingPrinterOpts p1 p2 =
 data CommaStyle
   = Leading
   | Trailing
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, Bounded, Enum)
 
 instance FromJSON CommaStyle where
   parseJSON =
@@ -192,7 +192,7 @@ instance FromJSON CommaStyle where
 data HaddockPrintStyle
   = HaddockSingleLine
   | HaddockMultiLine
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, Bounded, Enum)
 
 instance FromJSON HaddockPrintStyle where
   parseJSON =


### PR DESCRIPTION
Closes #27.

This solves the problem described in #27. At the same time I wanted to reduce the number of places where the strings encoding option values were hardcoded, which resulted in rewriting/replacing `parseHaddockStyle`, `parseCommaStyle` and `parseBool` and modifying the way that the help texts are built.

I also decided to make the error messages a bit more user friendly by providing the user with the list of possible values of an option (because it was nearly free with the new approach).

Some comments:
1. I don't understand why booleans are case-insensitive and other options are case-sensitive. Do we really want it this way?
2. The values can still be represented in different ways on the command line and in the config file. I think it would be nice if we had a single source of truth, guaranteeing that these representations are uniform. However, I'm not sure what is the best approach to this problem. But anyway, I think this is out of scope for this issue/PR.
