### PR TITLE
Configurable newlines between declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ indent-wheres: false # 'false' means save space by only half-indenting the 'wher
 diff-friendly-import-export: true # 'false' uses Ormolu-style lists
 respectful: true # don't be too opinionated about newlines etc.
 haddock-style: multi-line # '--' vs. '{-'
+newlines-between-decls: 1 # Number of newlines between declarations
 ```
 
 See [here](fourmolu.yaml) for a config to simulate the behaviour of Ormolu.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -258,6 +258,12 @@ printerOptsParser = do
         metavar "STYLE",
         help "How to print Haddock comments (default 'multi-line')"
       ]
+  poNewlinesBetweenDecls <-
+    (optional . option auto . mconcat)
+      [ long "newlines-between-decls",
+        metavar "HEIGHT",
+        help "Number of spaces between top-level declarations (default 1)"
+      ]
   pure PrinterOpts {..}
 
 ----------------------------------------------------------------------------

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -118,7 +118,9 @@ data PrinterOpts f = PrinterOpts
     -- | Be less opinionated about spaces/newlines etc.
     poRespectful :: f Bool,
     -- | How to print doc comments
-    poHaddockStyle :: f HaddockPrintStyle
+    poHaddockStyle :: f HaddockPrintStyle,
+    -- | Number of newlines between top-level decls
+    poNewlinesBetweenDecls :: f Int
   }
   deriving (Generic)
 
@@ -134,7 +136,7 @@ instance Semigroup PrinterOptsPartial where
   (<>) = fillMissingPrinterOpts
 
 instance Monoid PrinterOptsPartial where
-  mempty = PrinterOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+  mempty = PrinterOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 -- | A version of 'PrinterOpts' without empty fields.
 type PrinterOptsTotal = PrinterOpts Identity
@@ -152,7 +154,8 @@ defaultPrinterOpts =
       poRecordBraceSpace = pure False,
       poDiffFriendlyImportExport = pure True,
       poRespectful = pure True,
-      poHaddockStyle = pure HaddockMultiLine
+      poHaddockStyle = pure HaddockMultiLine,
+      poNewlinesBetweenDecls = pure 1
     }
 
 -- | Fill the field values that are 'Nothing' in the first argument
@@ -171,7 +174,8 @@ fillMissingPrinterOpts p1 p2 =
       poRecordBraceSpace = fillField poRecordBraceSpace,
       poDiffFriendlyImportExport = fillField poDiffFriendlyImportExport,
       poRespectful = fillField poRespectful,
-      poHaddockStyle = fillField poHaddockStyle
+      poHaddockStyle = fillField poHaddockStyle,
+      poNewlinesBetweenDecls = fillField poNewlinesBetweenDecls
     }
   where
     fillField :: (forall g. PrinterOpts g -> g a) -> f a

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -30,7 +30,6 @@ module Ormolu.Printer.Combinators
     Layout (..),
     vlayout,
     getLayout,
-    declBreakpoint,
     breakpoint,
     breakpoint',
     getPrinterOpt,
@@ -137,13 +136,6 @@ spansLayout = \case
     if isOneLineSpan (foldr combineSrcSpans x xs)
       then SingleLine
       else MultiLine
-
--- | Insert a space if enclosing layout is single-line, or 'declNewline' if it's
--- multiline.
---
--- > declBreakpoint = vlayout space declNewline
-declBreakpoint :: R ()
-declBreakpoint = vlayout space declNewline
 
 -- | Insert a space if enclosing layout is single-line, or newline if it's
 -- multiline.

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -20,6 +20,7 @@ module Ormolu.Printer.Combinators
     atom,
     space,
     newline,
+    declNewline,
     inci,
     inciIf,
     inciBy,
@@ -29,6 +30,7 @@ module Ormolu.Printer.Combinators
     Layout (..),
     vlayout,
     getLayout,
+    declBreakpoint,
     breakpoint,
     breakpoint',
     getPrinterOpt,
@@ -135,6 +137,13 @@ spansLayout = \case
     if isOneLineSpan (foldr combineSrcSpans x xs)
       then SingleLine
       else MultiLine
+
+-- | Insert a space if enclosing layout is single-line, or 'declNewline' if it's
+-- multiline.
+--
+-- > declBreakpoint = vlayout space declNewline
+declBreakpoint :: R ()
+declBreakpoint = vlayout space declNewline
 
 -- | Insert a space if enclosing layout is single-line, or newline if it's
 -- multiline.

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -384,7 +384,7 @@ newlineRaw = R . modify $ \sc ->
           scColumn = 0,
           scIndent = 0,
           scThisLineSpans = [],
-          scRequestedDelimiter = case requestedDel of
+          scRequestedDelimiter = case scRequestedDelimiter sc of
             AfterNewline -> RequestedNewline
             RequestedNewline -> RequestedNewline
             VeryBeginning -> VeryBeginning

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -318,22 +318,7 @@ space = R . modify $ \sc ->
     }
 
 declNewline :: R ()
-declNewline = newlineRawN . pred =<< getPrinterOpt poNewlinesBetweenDecls
-
--- | Low-level newline primitive. This always inserts 'n' newlines.
-newlineRawN :: Int -> R ()
-newlineRawN n = R . modify $ \sc ->
-  sc
-    { scBuilder = scBuilder sc <> mconcat (replicate n "\n"),
-      scColumn = 0,
-      scIndent = 0,
-      scThisLineSpans = [],
-      scRequestedDelimiter = case scRequestedDelimiter sc of
-        AfterNewline -> RequestedNewline
-        RequestedNewline -> RequestedNewline
-        VeryBeginning -> VeryBeginning
-        _ -> AfterNewline
-    }
+declNewline = newlineRawN =<< getPrinterOpt poNewlinesBetweenDecls
 
 -- | Output a newline. First time 'newline' is used after some non-'newline'
 -- output it gets inserted immediately. Second use of 'newline' does not
@@ -372,15 +357,20 @@ newline = do
 -- | Low-level newline primitive. This one always just inserts a newline, no
 -- hooks can be attached.
 newlineRaw :: R ()
-newlineRaw = R . modify $ \sc ->
+newlineRaw = newlineRawN 1
+
+-- | Low-level newline primitive. This always inserts 'n' newlines.
+newlineRawN :: Int -> R ()
+newlineRawN n = R . modify $ \sc ->
   let requestedDel = scRequestedDelimiter sc
       builderSoFar = scBuilder sc
+      n' = case requestedDel of
+        AfterNewline -> n - 1
+        RequestedNewline -> n - 1
+        VeryBeginning -> n - 1
+        _ -> n
    in sc
-        { scBuilder = case requestedDel of
-            AfterNewline -> builderSoFar
-            RequestedNewline -> builderSoFar
-            VeryBeginning -> builderSoFar
-            _ -> builderSoFar <> "\n",
+        { scBuilder = builderSoFar <> mconcat (replicate n' "\n"),
           scColumn = 0,
           scIndent = 0,
           scThisLineSpans = [],

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -68,12 +68,12 @@ p_hsDecls' grouping style decls =
       -- ensure we always add blank lines around documented declarations
       case grouping of
         Disregard ->
-          breakpoint : renderGroup curr
+          declBreakpoint : renderGroup curr
         Respect ->
           if separatedByBlankNE getLoc prev curr
             || isDocumented prev
             || isDocumented curr
-            then breakpoint : renderGroup curr
+            then declBreakpoint : renderGroup curr
             else renderGroup curr
 
 -- | Is a declaration group documented?

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -68,12 +68,12 @@ p_hsDecls' grouping style decls =
       -- ensure we always add blank lines around documented declarations
       case grouping of
         Disregard ->
-          declBreakpoint : renderGroup curr
+          declNewline : renderGroup curr
         Respect ->
           if separatedByBlankNE getLoc prev curr
             || isDocumented prev
             || isDocumented curr
-            then declBreakpoint : renderGroup curr
+            then declNewline : renderGroup curr
             else renderGroup curr
 
 -- | Is a declaration group documented?

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -79,7 +79,7 @@ p_hsModule mstackHeader shebangs pragmas qualifiedPost HsModule {..} = do
     forM_ (normalizeImports preserveGroups hsmodImports) $ \importGroup -> do
       forM_ importGroup (located' (p_hsmodImport qualifiedPost))
       newline
-    newline
+    declNewline
     switchLayout (getLoc <$> hsmodDecls) $ do
       preserveSpacing <- getPrinterOpt poRespectful
       (if preserveSpacing then p_hsDeclsRespectGrouping else p_hsDecls) Free hsmodDecls

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -23,7 +23,7 @@ where
 
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
-import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -135,7 +135,9 @@ onTheSameLine a b =
 removeIndentation :: String -> (String, Int)
 removeIndentation (lines -> xs) = (unlines (drop n <$> xs), n)
   where
-    n = minimum (getIndent <$> xs)
+    n = case nonEmpty xs of
+      Nothing -> 0
+      Just l -> minimum (getIndent <$> l)
     getIndent y =
       if all isSpace y
         then 0

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -27,7 +27,8 @@ spec = do
             poRecordBraceSpace = pure True,
             poDiffFriendlyImportExport = pure False,
             poRespectful = pure False,
-            poHaddockStyle = pure HaddockSingleLine
+            poHaddockStyle = pure HaddockSingleLine,
+            poNewlinesBetweenDecls = pure 1
           }
   sequence_ $ uncurry checkExample <$> [(ormoluOpts, ""), (defaultPrinterOpts, "-four")] <*> es
 


### PR DESCRIPTION
The number of newlines between declarations can now be configured with 'newlines-between-decls' configuration option.

Closes #47 

This does exactly what I want! It's idempotent as well. It defaults to exactly ormolu behavior. I tested it on our large industrial codebase. I don't see anything unexpected from my initial skim. If we merge this, I think we'd start using this at @bitnomial.