### PR TITLE
Remove hardcoded default for poNewlinesBetweenDecls from help text.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -279,7 +279,9 @@ printerOptsParser = do
     (optional . option auto . mconcat)
       [ long "newlines-between-decls",
         metavar "HEIGHT",
-        help "Number of spaces between top-level declarations (default 1)"
+        help $
+          "Number of spaces between top-level declarations"
+            <> showDefaultValue poNewlinesBetweenDecls
       ]
   pure PrinterOpts {..}
 


### PR DESCRIPTION
This just applies the machinery of #44 to the new option `--newlines-between-decls` introduced in #48 (so that we use the default value of `poNewlinesBetweenDecls` from `defaultPrinterOpts` instead of hardcoding it in the help text).