### PR TITLE
Relax aeson version lower bound requirement

### DIFF
--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -117,7 +117,7 @@ library
 
     default-language: Haskell2010
     build-depends:
-        aeson >=1.5.2 && <1.6,
+        aeson >=1.4.0.0 && <1.6,
         base >=4.12 && <5.0,
         bytestring >=0.2 && <0.11,
         containers >=0.5 && <0.7,


### PR DESCRIPTION
As instructed in the README, ran `cabal test` and `./format.sh` and had no issues.

I would really appreciate if the hackage metadata could be updated after this is merged.

Thanks!