### PR TITLE
Also insert newline after 'in'

### DIFF
--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -946,8 +946,13 @@ p_let render localBinds e = sitcc $ do
       dontUseBraces $ sitcc (located localBinds p_hsLocalBinds)
   vlayout space (newline >> txt " ")
   txt "in"
-  space
-  sitcc (located e render)
+  getPrinterOpt poLetNewline >>= \case
+    True -> do
+      vlayout space newline
+      inci (located e render)
+    False -> do
+      space
+      sitcc (located e render)
 
 p_pat :: Pat GhcPs -> R ()
 p_pat = \case


### PR DESCRIPTION
C.f. https://github.com/parsonsmatt/fourmolu/pull/77#issuecomment-818634693

Not sure whether we'd like it gated by another option.