### PR TITLE
New option: "space between type and constructor"

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -283,6 +283,14 @@ printerOptsParser = do
           "Number of spaces between top-level declarations"
             <> showDefaultValue poNewlinesBetweenDecls
       ]
+  poAddSpaceBetweenImportedTypeAndConstructor <-
+    (optional . option parseBoundedEnum . mconcat)
+      [ long "space-between-type-and-constructor",
+        metavar "BOOL",
+        help $
+          "Whether to add space between type and its constructor(s) in import"
+            <> showDefaultValue poAddSpaceBetweenImportedTypeAndConstructor
+      ]
   pure PrinterOpts {..}
 
 ----------------------------------------------------------------------------

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -120,7 +120,9 @@ data PrinterOpts f = PrinterOpts
     -- | How to print doc comments
     poHaddockStyle :: f HaddockPrintStyle,
     -- | Number of newlines between top-level decls
-    poNewlinesBetweenDecls :: f Int
+    poNewlinesBetweenDecls :: f Int,
+    -- | Whether to add space between type and its constructor(s) in import
+    poAddSpaceBetweenImportedTypeAndConstructor :: f Bool
   }
   deriving (Generic)
 
@@ -136,7 +138,7 @@ instance Semigroup PrinterOptsPartial where
   (<>) = fillMissingPrinterOpts
 
 instance Monoid PrinterOptsPartial where
-  mempty = PrinterOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+  mempty = PrinterOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 -- | A version of 'PrinterOpts' without empty fields.
 type PrinterOptsTotal = PrinterOpts Identity
@@ -155,7 +157,8 @@ defaultPrinterOpts =
       poDiffFriendlyImportExport = pure True,
       poRespectful = pure True,
       poHaddockStyle = pure HaddockMultiLine,
-      poNewlinesBetweenDecls = pure 1
+      poNewlinesBetweenDecls = pure 1,
+      poAddSpaceBetweenImportedTypeAndConstructor = pure True
     }
 
 -- | Fill the field values that are 'Nothing' in the first argument
@@ -175,7 +178,8 @@ fillMissingPrinterOpts p1 p2 =
       poDiffFriendlyImportExport = fillField poDiffFriendlyImportExport,
       poRespectful = fillField poRespectful,
       poHaddockStyle = fillField poHaddockStyle,
-      poNewlinesBetweenDecls = fillField poNewlinesBetweenDecls
+      poNewlinesBetweenDecls = fillField poNewlinesBetweenDecls,
+      poAddSpaceBetweenImportedTypeAndConstructor = fillField poAddSpaceBetweenImportedTypeAndConstructor
     }
   where
     fillField :: (forall g. PrinterOpts g -> g a) -> f a

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -62,11 +62,8 @@ p_hsmodImport useQualifiedPost ImportDecl {..} = do
     space
     case ideclHiding of
       Nothing -> return ()
-      Just (hiding, _) ->
+      Just (hiding, L _ xs) -> do
         when hiding (txt "hiding")
-    case ideclHiding of
-      Nothing -> return ()
-      Just (_, L _ xs) -> do
         breakIfNotDiffFriendly
         parens' True $ do
           layout <- getLayout

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -13,7 +13,7 @@ where
 import Control.Monad
 import qualified Data.Text as T
 import GHC
-import Ormolu.Config (poDiffFriendlyImportExport)
+import Ormolu.Config (poAddSpaceBetweenImportedTypeAndConstructor, poDiffFriendlyImportExport)
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import Ormolu.Utils (RelativePos (..), attachRelativePos)
@@ -84,12 +84,14 @@ p_lie encLayout relativePos = \case
     p_comma
   IEThingAll NoExtField l1 -> do
     located l1 p_ieWrappedName
-    space
+    addSpace <- getPrinterOpt poAddSpaceBetweenImportedTypeAndConstructor
+    when (addSpace) space
     txt "(..)"
     p_comma
   IEThingWith NoExtField l1 w xs _ -> sitcc $ do
     located l1 p_ieWrappedName
-    breakIfNotDiffFriendly
+    addSpace <- getPrinterOpt poAddSpaceBetweenImportedTypeAndConstructor
+    when (addSpace) breakIfNotDiffFriendly
     inci $ do
       let names :: [R ()]
           names = located' p_ieWrappedName <$> xs

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -28,7 +28,8 @@ spec = do
             poDiffFriendlyImportExport = pure False,
             poRespectful = pure False,
             poHaddockStyle = pure HaddockSingleLine,
-            poNewlinesBetweenDecls = pure 1
+            poNewlinesBetweenDecls = pure 1,
+            poAddSpaceBetweenImportedTypeAndConstructor = pure True
           }
   sequence_ $ uncurry checkExample <$> [(ormoluOpts, ""), (defaultPrinterOpts, "-four")] <*> es
 


### PR DESCRIPTION
Adds a configurable option whether to add or not a space between type and its constructors in imports.

Example:
```
-- fourmolu --space-between-type-and-constructor false
import Foo (Bar(..), (.!))
import Quux (Burp(Cat, Dog), (.!))
```
```
-- fourmolu --space-between-type-and-constructor true
import Foo (Bar (..), (.!))
import Quux (Burp (Cat, Dog), (.!))
```

Default value: true, same behavior as on master.